### PR TITLE
When interpreting a byte-array as BigInteger, must include signum=1.

### DIFF
--- a/src/main/java/com/ibm/zurich/crypto/BNCurve.java
+++ b/src/main/java/com/ibm/zurich/crypto/BNCurve.java
@@ -170,7 +170,7 @@ public class BNCurve {
 	public BigInteger getRandomModOrder(SecureRandom random) {
 		byte[] randomBytes = new byte[(this.order.bitLength()+STAT_INDIST_PARAM)/8];
 		random.nextBytes(randomBytes);
-		return new BigInteger(randomBytes).mod(this.order);
+		return new BigInteger(1, randomBytes).mod(this.order);
 	}
 	
 	/**
@@ -346,7 +346,7 @@ public class BNCurve {
 	 * @throws NoSuchAlgorithmException
 	 */
 	public BigInteger hashModOrder(byte[]... preimageArray) throws NoSuchAlgorithmException {
-		return new BigInteger(this.hash(preimageArray)).mod(this.getOrder());
+		return new BigInteger(1, this.hash(preimageArray)).mod(this.getOrder());
 	}
 	
 	/**


### PR DESCRIPTION
fixes #2 

(sorry, when I first tried submitting a PR, it looked like github wouldn't let me, so I submitted it as an issue instead)